### PR TITLE
Add package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /libexec/*.dylib
 /src/Makefile
 /src/*.o
+/node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/helpers/assertions"]
-	path = test/helpers/assertions
-	url = https://github.com/jasonkarns/bats-assert

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ env:
 branches:
   only:
     - master
+notifications:
+  email:
+    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
-branches:
-  only:
-    - master
-install: git clone --depth 1 https://github.com/sstephenson/bats.git
-script: PATH="./bats/bin:$PATH" test/run
-language: c
+language: node_js
+node_js: node
 env:
   - NODENV_NATIVE_EXT=
   - NODENV_NATIVE_EXT=1
+branches:
+  only:
+    - master

--- a/libexec/nodenv---version
+++ b/libexec/nodenv---version
@@ -12,12 +12,14 @@
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
-version="1.0.0"
-git_revision=""
+cd "${BASH_SOURCE%/*}" 2>/dev/null
 
-if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q nodenv; then
+git_revision=""
+pkg_version="$(grep -e '"version":' ../package.json | awk -v FS=': ' '{v=$2; gsub(/[",]/,"",v); print v}')"
+
+if git remote -v 2>/dev/null | grep -q nodenv; then
   git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
   git_revision="${git_revision#v}"
 fi
 
-echo "nodenv ${git_revision:-$version}"
+echo "nodenv ${git_revision:-$pkg_version}"

--- a/libexec/nodenv-help
+++ b/libexec/nodenv-help
@@ -42,7 +42,7 @@ extract_initial_comment_block() {
 }
 
 collect_documentation() {
-  $(type -p gawk awk | head -1) '
+  $(type -p gawk awk 2>/dev/null | head -1) '
     /^Summary:/ {
       summary = substr($0, 10)
       next

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nodenv",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Manage multiple NodeJS versions",
+  "author": "Will McKenzie <willmckenzie@oinutter.co.uk> (http://www.oinutter.co.uk)",
+  "contributors": [
+    "Jason Karns <jason@karns.name> (http://jason.karns.name/)"
+  ],
+  "homepage": "https://github.com/nodenv/nodenv#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nodenv/nodenv.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nodenv/nodenv/issues"
+  },
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/nodenv/nodenv/issues"
   },
+  "scripts": {
+    "test": "bats ${CI:+--tap} test"
+  },
   "devDependencies": {
     "bats": "^0.4.2",
     "bats-assert": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/nodenv/nodenv/issues"
   },
   "scripts": {
+    "pretest": "script/build-native-ext",
     "test": "bats ${CI:+--tap} test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/nodenv/nodenv/issues"
   },
+  "devDependencies": {
+    "bats": "^0.4.2"
+  },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
   },
   "scripts": {
     "pretest": "script/build-native-ext",
-    "test": "bats ${CI:+--tap} test"
+    "test": "bats ${CI:+--tap} test",
+    "publish:brew": "brew-publish $npm_package_name"
   },
   "devDependencies": {
     "bats": "^0.4.2",
-    "bats-assert": "^1.0.1"
+    "bats-assert": "^1.0.1",
+    "brew-publish": "git+https://github.com/jasonkarns/brew-publish.git"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/nodenv/nodenv/issues"
   },
   "devDependencies": {
-    "bats": "^0.4.2"
+    "bats": "^0.4.2",
+    "bats-assert": "^1.0.1"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "pretest": "script/build-native-ext",
     "test": "bats ${CI:+--tap} test",
-    "publish:brew": "brew-publish $npm_package_name"
+    "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
+    "postversion": "git push origin master v$npm_package_version && npm run publish:brew"
   },
   "devDependencies": {
     "bats": "^0.4.2",

--- a/script/build-native-ext
+++ b/script/build-native-ext
@@ -5,5 +5,3 @@ if [ -n "$NODENV_NATIVE_EXT" ]; then
   src/configure
   make -C src
 fi
-
-exec bats ${CI:+--tap} test

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,4 @@
-load helpers/assertions/all
+load ../node_modules/bats-assert/all
 
 unset NODENV_VERSION
 unset NODENV_DIR


### PR DESCRIPTION
Adds package.json

- install bats via npm instead of git-clone
- install bats-assert via npm instead git-submodule
- switch travis config to use standard node test setup
    - defaults to npm-install instead of `install` in travis.yml
    - defaults to npm-test instead of `script` in travis.yml
- nodenv---version pulls version from package.json instead of hardcoded
- grab release script (for `preversion`/`postversion` hooks) from node-build (ensures proper git state before bumping version; triggers brew-publish after bump)
- grab brew-publish script from node-build to submit PR to homebrew after each version bump/release

Benefits:

- `npm install` will give us the necessary test dependencies (bats and bats-assert)
- `npm run` will list available scripts
- `npm test` to test
- `npm version <bump>` to do releases
- simpler travis configuration