### PR TITLE
[wip] Bats assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "devDependencies": {
     "bats": "^0.4.2",
-    "bats-assert": "^1.0.1",
+    "bats-assert": "git+https://github.com/jasonkarns/bats-assert-1.git#npm",
+    "bats-core": "git+https://github.com/jasonkarns/bats-core.git#npm",
     "brew-publish": "git+https://github.com/jasonkarns/brew-publish.git"
   }
 }

--- a/test/--version.bats
+++ b/test/--version.bats
@@ -42,7 +42,8 @@ git_commit() {
   git_commit
 
   run nodenv---version
-  assert_success "nodenv 0.4.1-2-g$(git rev-parse --short HEAD)"
+  assert_success
+  assert_output "nodenv 0.4.1-2-g$(git rev-parse --short HEAD)"
 }
 
 @test "prints default version if no tags in git repo" {

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -13,7 +13,8 @@ create_command() {
   create_command "nodenv-hello" "#!$BASH
     echo hello"
   run nodenv-completions hello
-  assert_success "--help"
+  assert_success
+  assert_output "--help"
 }
 
 @test "command with completion support" {

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -107,5 +107,6 @@ SH
 
   nodenv-rehash
   run node -S npm
-  assert_success "hello npm"
+  assert_success
+  assert_output "hello npm"
 }

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -17,7 +17,8 @@ create_executable() {
 @test "fails with invalid version" {
   export NODENV_VERSION="2.0"
   run nodenv-exec node -v
-  assert_failure "nodenv: version \`2.0' is not installed (set by NODENV_VERSION environment variable)"
+  assert_failure
+  assert_output "nodenv: version \`2.0' is not installed (set by NODENV_VERSION environment variable)"
 }
 
 @test "fails with invalid version set from file" {
@@ -25,7 +26,8 @@ create_executable() {
   cd "$NODENV_TEST_DIR"
   echo 1.9 > .node-version
   run nodenv-exec npm
-  assert_failure "nodenv: version \`1.9' is not installed (set by $PWD/.node-version)"
+  assert_failure
+  assert_output "nodenv: version \`1.9' is not installed (set by $PWD/.node-version)"
 }
 
 @test "completes with names of executables" {

--- a/test/global.bats
+++ b/test/global.bats
@@ -21,7 +21,8 @@ load test_helper
   run nodenv-global "1.2.3"
   assert_success
   run nodenv-global
-  assert_success "1.2.3"
+  assert_success
+  assert_output "1.2.3"
 }
 
 @test "fail setting invalid NODENV_ROOT/version" {

--- a/test/global.bats
+++ b/test/global.bats
@@ -39,7 +39,7 @@ load test_helper
   run nodenv-global --unset
   assert_success
 
-  refute [ -e $NODENV_ROOT/version ]
+  assert [ ! -e $NODENV_ROOT/version ]
   run nodenv-global
   assert_output "system"
 }

--- a/test/global.bats
+++ b/test/global.bats
@@ -27,7 +27,8 @@ load test_helper
 @test "fail setting invalid NODENV_ROOT/version" {
   mkdir -p "$NODENV_ROOT"
   run nodenv-global "1.2.3"
-  assert_failure "nodenv: version \`1.2.3' not installed"
+  assert_failure
+  assert_output "nodenv: version \`1.2.3' not installed"
 }
 
 @test "unset (remove) NODENV_ROOT/version" {

--- a/test/help.bats
+++ b/test/help.bats
@@ -11,7 +11,8 @@ load test_helper
 
 @test "invalid command" {
   run nodenv-help hello
-  assert_failure "nodenv: no such command \`hello'"
+  assert_failure
+  assert_output "nodenv: no such command \`hello'"
 }
 
 @test "shows help for a specific command" {

--- a/test/help.bats
+++ b/test/help.bats
@@ -63,7 +63,8 @@ echo hello
 SH
 
   run nodenv-help --usage hello
-  assert_success "Usage: nodenv hello <world>"
+  assert_success
+  assert_output "Usage: nodenv hello <world>"
 }
 
 @test "multiline usage section" {

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -4,7 +4,8 @@ load test_helper
 
 @test "prints usage help given no argument" {
   run nodenv-hooks
-  assert_failure "Usage: nodenv hooks <command>"
+  assert_failure
+  assert_output "Usage: nodenv hooks <command>"
 }
 
 @test "prints list of hooks" {

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -50,7 +50,8 @@ OUT
   mkdir -p "$HOME"
 
   NODENV_HOOK_PATH="${HOME}/../nodenv.d" run nodenv-hooks exec
-  assert_success "${NODENV_TEST_DIR}/nodenv.d/exec/hello.bash"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/nodenv.d/exec/hello.bash"
 }
 
 @test "resolves symlinks" {

--- a/test/init.bats
+++ b/test/init.bats
@@ -66,28 +66,28 @@ OUT
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run nodenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${NODENV_ROOT}'/shims:${PATH}"'
+  assert_line -n 0 'export PATH="'${NODENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run nodenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
+  assert_line -n 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
   export PATH="${NODENV_ROOT}/shims:$PATH"
   run nodenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${NODENV_ROOT}'/shims:${PATH}"'
+  assert_line -n 0 'export PATH="'${NODENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "can add shims to PATH more than once (fish)" {
   export PATH="${NODENV_ROOT}/shims:$PATH"
   run nodenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
+  assert_line -n 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {

--- a/test/init.bats
+++ b/test/init.bats
@@ -40,7 +40,8 @@ echo \$NODENV_SHELL
 OUT
   chmod +x myscript.sh
   run ./myscript.sh /bin/zsh
-  assert_success "sh"
+  assert_success
+  assert_output "sh"
 }
 
 @test "setup shell completions (fish)" {

--- a/test/local.bats
+++ b/test/local.bats
@@ -17,14 +17,16 @@ setup() {
 @test "local version" {
   echo "1.2.3" > .node-version
   run nodenv-local
-  assert_success "1.2.3"
+  assert_success
+  assert_output "1.2.3"
 }
 
 @test "discovers version file in parent directory" {
   echo "1.2.3" > .node-version
   mkdir -p "subdir" && cd "subdir"
   run nodenv-local
-  assert_success "1.2.3"
+  assert_success
+  assert_output "1.2.3"
 }
 
 @test "ignores NODENV_DIR" {
@@ -32,13 +34,15 @@ setup() {
   mkdir -p "$HOME"
   echo "2.0-home" > "${HOME}/.node-version"
   NODENV_DIR="$HOME" run nodenv-local
-  assert_success "1.2.3"
+  assert_success
+  assert_output "1.2.3"
 }
 
 @test "sets local version" {
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   run nodenv-local 1.2.3
-  assert_success ""
+  assert_success
+  assert_output ""
   assert [ "$(cat .node-version)" = "1.2.3" ]
 }
 
@@ -46,15 +50,18 @@ setup() {
   echo "1.0-pre" > .node-version
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   run nodenv-local
-  assert_success "1.0-pre"
+  assert_success
+  assert_output "1.0-pre"
   run nodenv-local 1.2.3
-  assert_success ""
+  assert_success
+  assert_output ""
   assert [ "$(cat .node-version)" = "1.2.3" ]
 }
 
 @test "unsets local version" {
   touch .node-version
   run nodenv-local --unset
-  assert_success ""
+  assert_success
+  assert_output ""
   refute [ -e .node-version ]
 }

--- a/test/local.bats
+++ b/test/local.bats
@@ -10,7 +10,8 @@ setup() {
 @test "no version" {
   assert [ ! -e "${PWD}/.node-version" ]
   run nodenv-local
-  assert_failure "nodenv: no local version configured for this directory"
+  assert_failure
+  assert_output "nodenv: no local version configured for this directory"
 }
 
 @test "local version" {

--- a/test/local.bats
+++ b/test/local.bats
@@ -63,5 +63,5 @@ setup() {
   run nodenv-local --unset
   assert_success
   assert_output ""
-  refute [ -e .node-version ]
+  assert [ ! -e .node-version ]
 }

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -48,7 +48,8 @@ load test_helper
 
 @test "adds its own libexec to PATH" {
   run nodenv echo "PATH"
-  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+  assert_success
+  assert_output "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
 }
 
 @test "adds plugin bin dirs to PATH" {
@@ -72,5 +73,6 @@ load test_helper
 @test "NODENV_HOOK_PATH includes nodenv built-in plugins" {
   unset NODENV_HOOK_PATH
   run nodenv echo "NODENV_HOOK_PATH"
-  assert_success "${NODENV_ROOT}/nodenv.d:${BATS_TEST_DIRNAME%/*}/nodenv.d:/usr/local/etc/nodenv.d:/etc/nodenv.d:/usr/lib/nodenv/hooks"
+  assert_success
+  assert_output "${NODENV_ROOT}/nodenv.d:${BATS_TEST_DIRNAME%/*}/nodenv.d:/usr/local/etc/nodenv.d:/etc/nodenv.d:/usr/lib/nodenv/hooks"
 }

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "blank invocation" {
   run nodenv
   assert_failure
-  assert_line 0 "$(nodenv---version)"
+  assert_line -n 0 "$(nodenv---version)"
 }
 
 @test "invalid command" {
@@ -56,17 +56,17 @@ load test_helper
   mkdir -p "$NODENV_ROOT"/plugins/nodenv-each/bin
   run nodenv echo -F: "PATH"
   assert_success
-  assert_line 0 "${BATS_TEST_DIRNAME%/*}/libexec"
-  assert_line 1 "${NODENV_ROOT}/plugins/nodenv-each/bin"
-  assert_line 2 "${NODENV_ROOT}/plugins/node-build/bin"
+  assert_line -n 0 "${BATS_TEST_DIRNAME%/*}/libexec"
+  assert_line -n 1 "${NODENV_ROOT}/plugins/nodenv-each/bin"
+  assert_line -n 2 "${NODENV_ROOT}/plugins/node-build/bin"
 }
 
 @test "NODENV_HOOK_PATH preserves value from environment" {
   NODENV_HOOK_PATH=/my/hook/path:/other/hooks run nodenv echo -F: "NODENV_HOOK_PATH"
   assert_success
-  assert_line 0 "/my/hook/path"
-  assert_line 1 "/other/hooks"
-  assert_line 2 "${NODENV_ROOT}/nodenv.d"
+  assert_line -n 0 "/my/hook/path"
+  assert_line -n 1 "/other/hooks"
+  assert_line -n 2 "${NODENV_ROOT}/nodenv.d"
 }
 
 @test "NODENV_HOOK_PATH includes nodenv built-in plugins" {

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -8,7 +8,8 @@ load test_helper
   echo "1.2.3" > .node-version
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   run nodenv-prefix
-  assert_success "${NODENV_ROOT}/versions/1.2.3"
+  assert_success
+  assert_output "${NODENV_ROOT}/versions/1.2.3"
 }
 
 @test "prefix for invalid version" {
@@ -22,7 +23,8 @@ load test_helper
   touch "${NODENV_TEST_DIR}/bin/node"
   chmod +x "${NODENV_TEST_DIR}/bin/node"
   NODENV_VERSION="system" run nodenv-prefix
-  assert_success "$NODENV_TEST_DIR"
+  assert_success
+  assert_output "$NODENV_TEST_DIR"
 }
 
 @test "prefix for invalid system" {

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -13,7 +13,8 @@ load test_helper
 
 @test "prefix for invalid version" {
   NODENV_VERSION="1.2.3" run nodenv-prefix
-  assert_failure "nodenv: version \`1.2.3' not installed"
+  assert_failure
+  assert_output "nodenv: version \`1.2.3' not installed"
 }
 
 @test "prefix for system" {
@@ -26,5 +27,6 @@ load test_helper
 
 @test "prefix for invalid system" {
   PATH="$(path_without node)" run nodenv-prefix system
-  assert_failure "nodenv: system version not found in PATH"
+  assert_failure
+  assert_output "nodenv: system version not found in PATH"
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -21,14 +21,16 @@ create_executable() {
   mkdir -p "${NODENV_ROOT}/shims"
   chmod -w "${NODENV_ROOT}/shims"
   run nodenv-rehash
-  assert_failure "nodenv: cannot rehash: ${NODENV_ROOT}/shims isn't writable"
+  assert_failure
+  assert_output "nodenv: cannot rehash: ${NODENV_ROOT}/shims isn't writable"
 }
 
 @test "rehash in progress" {
   mkdir -p "${NODENV_ROOT}/shims"
   touch "${NODENV_ROOT}/shims/.nodenv-shim"
   run nodenv-rehash
-  assert_failure "nodenv: cannot rehash: ${NODENV_ROOT}/shims/.nodenv-shim exists"
+  assert_failure
+  assert_output "nodenv: cannot rehash: ${NODENV_ROOT}/shims/.nodenv-shim exists"
 }
 
 @test "creates shims" {

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -12,7 +12,8 @@ create_executable() {
 @test "empty rehash" {
   assert [ ! -d "${NODENV_ROOT}/shims" ]
   run nodenv-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
   assert [ -d "${NODENV_ROOT}/shims" ]
   rmdir "${NODENV_ROOT}/shims"
 }
@@ -43,7 +44,8 @@ create_executable() {
   assert [ ! -e "${NODENV_ROOT}/shims/npm" ]
 
   run nodenv-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
 
   run ls "${NODENV_ROOT}/shims"
   assert_success
@@ -62,7 +64,8 @@ OUT
   create_executable "2.0" "node"
 
   run nodenv-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
 
   assert [ ! -e "${NODENV_ROOT}/shims/oldshim1" ]
 }
@@ -79,7 +82,8 @@ OUT
   chmod +x "$NODENV_ROOT"/shims/{rspec,rails,uni}
 
   run nodenv-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
 
   assert [ ! -e "${NODENV_ROOT}/shims/rails" ]
   assert [ ! -e "${NODENV_ROOT}/shims/rake" ]
@@ -94,7 +98,8 @@ OUT
   assert [ ! -e "${NODENV_ROOT}/shims/npm" ]
 
   run nodenv-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
 
   run ls "${NODENV_ROOT}/shims"
   assert_success
@@ -119,13 +124,15 @@ SH
 @test "sh-rehash in bash" {
   create_executable "2.0" "node"
   NODENV_SHELL=bash run nodenv-sh-rehash
-  assert_success "hash -r 2>/dev/null || true"
+  assert_success
+  assert_output "hash -r 2>/dev/null || true"
   assert [ -x "${NODENV_ROOT}/shims/node" ]
 }
 
 @test "sh-rehash in fish" {
   create_executable "2.0" "node"
   NODENV_SHELL=fish run nodenv-sh-rehash
-  assert_success ""
+  assert_success
+  assert_output ""
   assert [ -x "${NODENV_ROOT}/shims/node" ]
 }

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -13,22 +13,26 @@ load test_helper
 
 @test "shell version" {
   NODENV_SHELL=bash NODENV_VERSION="1.2.3" run nodenv-sh-shell
-  assert_success 'echo "$NODENV_VERSION"'
+  assert_success
+  assert_output 'echo "$NODENV_VERSION"'
 }
 
 @test "shell version (fish)" {
   NODENV_SHELL=fish NODENV_VERSION="1.2.3" run nodenv-sh-shell
-  assert_success 'echo "$NODENV_VERSION"'
+  assert_success
+  assert_output 'echo "$NODENV_VERSION"'
 }
 
 @test "shell unset" {
   NODENV_SHELL=bash run nodenv-sh-shell --unset
-  assert_success "unset NODENV_VERSION"
+  assert_success
+  assert_output "unset NODENV_VERSION"
 }
 
 @test "shell unset (fish)" {
   NODENV_SHELL=fish run nodenv-sh-shell --unset
-  assert_success "set -e NODENV_VERSION"
+  assert_success
+  assert_output "set -e NODENV_VERSION"
 }
 
 @test "shell change invalid version" {
@@ -43,11 +47,13 @@ SH
 @test "shell change version" {
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   NODENV_SHELL=bash run nodenv-sh-shell 1.2.3
-  assert_success 'export NODENV_VERSION="1.2.3"'
+  assert_success
+  assert_output 'export NODENV_VERSION="1.2.3"'
 }
 
 @test "shell change version (fish)" {
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   NODENV_SHELL=fish run nodenv-sh-shell 1.2.3
-  assert_success 'setenv NODENV_VERSION "1.2.3"'
+  assert_success
+  assert_output 'setenv NODENV_VERSION "1.2.3"'
 }

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -7,7 +7,8 @@ load test_helper
   cd "${NODENV_TEST_DIR}/myproject"
   echo "1.2.3" > .node-version
   NODENV_VERSION="" run nodenv-sh-shell
-  assert_failure "nodenv: no shell-specific version configured"
+  assert_failure
+  assert_output "nodenv: no shell-specific version configured"
 }
 
 @test "shell version" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,5 @@
-load ../node_modules/bats-assert/all
+load ../node_modules/bats-core/load
+load ../node_modules/bats-assert/load
 
 unset NODENV_VERSION
 unset NODENV_DIR

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -29,19 +29,22 @@ setup() {
 @test "reads simple version file" {
   cat > my-version <<<"1.9.3"
   run nodenv-version-file-read my-version
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "ignores leading spaces" {
   cat > my-version <<<"  1.9.3"
   run nodenv-version-file-read my-version
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "reads only the first word from file" {
   cat > my-version <<<"1.9.3-p194@tag 1.8.7 hi"
   run nodenv-version-file-read my-version
-  assert_success "1.9.3-p194@tag"
+  assert_success
+  assert_output "1.9.3-p194@tag"
 }
 
 @test "loads only the first line in file" {
@@ -50,7 +53,8 @@ setup() {
 1.9.3 two
 IN
   run nodenv-version-file-read my-version
-  assert_success "1.8.7"
+  assert_success
+  assert_output "1.8.7"
 }
 
 @test "ignores leading blank lines" {
@@ -59,17 +63,20 @@ IN
 1.9.3
 IN
   run nodenv-version-file-read my-version
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "handles the file with no trailing newline" {
   echo -n "1.8.7" > my-version
   run nodenv-version-file-read my-version
-  assert_success "1.8.7"
+  assert_success
+  assert_output "1.8.7"
 }
 
 @test "ignores carriage returns" {
   cat > my-version <<< $'1.9.3\r'
   run nodenv-version-file-read my-version
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -9,18 +9,21 @@ setup() {
 
 @test "fails without arguments" {
   run nodenv-version-file-read
-  assert_failure ""
+  assert_failure
+  assert_output ""
 }
 
 @test "fails for invalid file" {
   run nodenv-version-file-read "non-existent"
-  assert_failure ""
+  assert_failure
+  assert_output ""
 }
 
 @test "fails for blank file" {
   echo > my-version
   run nodenv-version-file-read my-version
-  assert_failure ""
+  assert_failure
+  assert_output ""
 }
 
 @test "reads simple version file" {

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -9,7 +9,8 @@ setup() {
 
 @test "invocation without 2 arguments prints usage" {
   run nodenv-version-file-write
-  assert_failure "Usage: nodenv version-file-write <file> <version>"
+  assert_failure
+  assert_output "Usage: nodenv version-file-write <file> <version>"
   run nodenv-version-file-write "one" ""
   assert_failure
 }
@@ -17,7 +18,8 @@ setup() {
 @test "setting nonexistent version fails" {
   assert [ ! -e ".node-version" ]
   run nodenv-version-file-write ".node-version" "1.8.7"
-  assert_failure "nodenv: version \`1.8.7' not installed"
+  assert_failure
+  assert_output "nodenv: version \`1.8.7' not installed"
   assert [ ! -e ".node-version" ]
 }
 

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -27,6 +27,7 @@ setup() {
   mkdir -p "${NODENV_ROOT}/versions/1.8.7"
   assert [ ! -e "my-version" ]
   run nodenv-version-file-write "${PWD}/my-version" "1.8.7"
-  assert_success ""
+  assert_success
+  assert_output ""
   assert [ "$(cat my-version)" = "1.8.7" ]
 }

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -20,8 +20,8 @@ create_file() {
 }
 
 @test "prints global file if no version files exist" {
-  refute [ -e "${NODENV_ROOT}/version" ]
-  refute [ -e ".ruby-version" ]
+  assert [ ! -e "${NODENV_ROOT}/version" ]
+  assert [ ! -e ".ruby-version" ]
   run nodenv-version-file
   assert_success
   assert_output "${NODENV_ROOT}/version"

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -15,20 +15,23 @@ create_file() {
 @test "detects global 'version' file" {
   create_file "${NODENV_ROOT}/version"
   run nodenv-version-file
-  assert_success "${NODENV_ROOT}/version"
+  assert_success
+  assert_output "${NODENV_ROOT}/version"
 }
 
 @test "prints global file if no version files exist" {
   refute [ -e "${NODENV_ROOT}/version" ]
   refute [ -e ".ruby-version" ]
   run nodenv-version-file
-  assert_success "${NODENV_ROOT}/version"
+  assert_success
+  assert_output "${NODENV_ROOT}/version"
 }
 
 @test "in current directory" {
   create_file ".node-version"
   run nodenv-version-file
-  assert_success "${NODENV_TEST_DIR}/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/.node-version"
 }
 
 @test "in parent directory" {
@@ -36,7 +39,8 @@ create_file() {
   mkdir -p project
   cd project
   run nodenv-version-file
-  assert_success "${NODENV_TEST_DIR}/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/.node-version"
 }
 
 @test "topmost file has precedence" {
@@ -44,7 +48,8 @@ create_file() {
   create_file "project/.node-version"
   cd project
   run nodenv-version-file
-  assert_success "${NODENV_TEST_DIR}/project/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/project/.node-version"
 }
 
 @test "NODENV_DIR has precedence over PWD" {
@@ -52,7 +57,8 @@ create_file() {
   create_file "project/.node-version"
   cd project
   NODENV_DIR="${NODENV_TEST_DIR}/widget" run nodenv-version-file
-  assert_success "${NODENV_TEST_DIR}/widget/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/widget/.node-version"
 }
 
 @test "PWD is searched if NODENV_DIR yields no results" {
@@ -60,13 +66,15 @@ create_file() {
   create_file "project/.node-version"
   cd project
   NODENV_DIR="${NODENV_TEST_DIR}/widget/blank" run nodenv-version-file
-  assert_success "${NODENV_TEST_DIR}/project/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/project/.node-version"
 }
 
 @test "finds version file in target directory" {
   create_file "project/.node-version"
   run nodenv-version-file "${PWD}/project"
-  assert_success "${NODENV_TEST_DIR}/project/.node-version"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/project/.node-version"
 }
 
 @test "fails when no version file in target directory" {

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -71,5 +71,6 @@ create_file() {
 
 @test "fails when no version file in target directory" {
   run nodenv-version-file "$PWD"
-  assert_failure ""
+  assert_failure
+  assert_output ""
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -14,12 +14,14 @@ setup() {
 @test "no version selected" {
   assert [ ! -d "${NODENV_ROOT}/versions" ]
   run nodenv-version-name
-  assert_success "system"
+  assert_success
+  assert_output "system"
 }
 
 @test "system version is not checked for existance" {
   NODENV_VERSION=system run nodenv-version-name
-  assert_success "system"
+  assert_success
+  assert_output "system"
 }
 
 @test "NODENV_VERSION can be overridden by hook" {
@@ -28,7 +30,8 @@ setup() {
   create_hook version-name test.bash <<<"NODENV_VERSION=1.9.3"
 
   NODENV_VERSION=1.8.7 run nodenv-version-name
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "carries original IFS within hooks" {
@@ -49,10 +52,12 @@ SH
 
   cat > ".node-version" <<<"1.8.7"
   run nodenv-version-name
-  assert_success "1.8.7"
+  assert_success
+  assert_output "1.8.7"
 
   NODENV_VERSION=1.9.3 run nodenv-version-name
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "local file has precedence over global" {
@@ -61,11 +66,13 @@ SH
 
   cat > "${NODENV_ROOT}/version" <<<"1.8.7"
   run nodenv-version-name
-  assert_success "1.8.7"
+  assert_success
+  assert_output "1.8.7"
 
   cat > ".node-version" <<<"1.9.3"
   run nodenv-version-name
-  assert_success "1.9.3"
+  assert_success
+  assert_output "1.9.3"
 }
 
 @test "missing version" {

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -70,7 +70,8 @@ SH
 
 @test "missing version" {
   NODENV_VERSION=1.2 run nodenv-version-name
-  assert_failure "nodenv: version \`1.2' is not installed (set by NODENV_VERSION environment variable)"
+  assert_failure
+  assert_output "nodenv: version \`1.2' is not installed (set by NODENV_VERSION environment variable)"
 }
 
 @test "version with prefix in name" {

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -10,32 +10,37 @@ setup() {
 @test "reports global file even if it doesn't exist" {
   assert [ ! -e "${NODENV_ROOT}/version" ]
   run nodenv-version-origin
-  assert_success "${NODENV_ROOT}/version"
+  assert_success
+  assert_output "${NODENV_ROOT}/version"
 }
 
 @test "detects global file" {
   mkdir -p "$NODENV_ROOT"
   touch "${NODENV_ROOT}/version"
   run nodenv-version-origin
-  assert_success "${NODENV_ROOT}/version"
+  assert_success
+  assert_output "${NODENV_ROOT}/version"
 }
 
 @test "detects NODENV_VERSION" {
   NODENV_VERSION=1 run nodenv-version-origin
-  assert_success "NODENV_VERSION environment variable"
+  assert_success
+  assert_output "NODENV_VERSION environment variable"
 }
 
 @test "detects local file" {
   touch .node-version
   run nodenv-version-origin
-  assert_success "${PWD}/.node-version"
+  assert_success
+  assert_output "${PWD}/.node-version"
 }
 
 @test "reports from hook" {
   create_hook version-origin test.bash <<<"NODENV_VERSION_ORIGIN=plugin"
 
   NODENV_VERSION=1 run nodenv-version-origin
-  assert_success "plugin"
+  assert_success
+  assert_output "plugin"
 }
 
 @test "carries original IFS within hooks" {
@@ -52,5 +57,6 @@ SH
 
 @test "doesn't inherit NODENV_VERSION_ORIGIN from environment" {
   NODENV_VERSION_ORIGIN=ignored run nodenv-version-origin
-  assert_success "${NODENV_ROOT}/version"
+  assert_success
+  assert_output "${NODENV_ROOT}/version"
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -14,25 +14,29 @@ setup() {
 @test "no version selected" {
   assert [ ! -d "${NODENV_ROOT}/versions" ]
   run nodenv-version
-  assert_success "system (set by ${NODENV_ROOT}/version)"
+  assert_success
+  assert_output "system (set by ${NODENV_ROOT}/version)"
 }
 
 @test "set by NODENV_VERSION" {
   create_version "1.9.3"
   NODENV_VERSION=1.9.3 run nodenv-version
-  assert_success "1.9.3 (set by NODENV_VERSION environment variable)"
+  assert_success
+  assert_output "1.9.3 (set by NODENV_VERSION environment variable)"
 }
 
 @test "set by local file" {
   create_version "1.9.3"
   cat > ".node-version" <<<"1.9.3"
   run nodenv-version
-  assert_success "1.9.3 (set by ${PWD}/.node-version)"
+  assert_success
+  assert_output "1.9.3 (set by ${PWD}/.node-version)"
 }
 
 @test "set by global file" {
   create_version "1.9.3"
   cat > "${NODENV_ROOT}/version" <<<"1.9.3"
   run nodenv-version
-  assert_success "1.9.3 (set by ${NODENV_ROOT}/version)"
+  assert_success
+  assert_output "1.9.3 (set by ${NODENV_ROOT}/version)"
 }

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -21,7 +21,8 @@ stub_system_node() {
   stub_system_node
   assert [ ! -d "${NODENV_ROOT}/versions" ]
   run nodenv-versions
-  assert_success "* system (set by ${NODENV_ROOT}/version)"
+  assert_success
+  assert_output "* system (set by ${NODENV_ROOT}/version)"
 }
 
 @test "not even system node available" {
@@ -33,7 +34,8 @@ stub_system_node() {
 @test "bare output no versions installed" {
   assert [ ! -d "${NODENV_ROOT}/versions" ]
   run nodenv-versions --bare
-  assert_success ""
+  assert_success
+  assert_output ""
 }
 
 @test "single version installed" {
@@ -50,7 +52,8 @@ OUT
 @test "single version bare" {
   create_version "1.9"
   run nodenv-versions --bare
-  assert_success "1.9"
+  assert_success
+  assert_output "1.9"
 }
 
 @test "multiple versions" {
@@ -125,7 +128,8 @@ OUT
   touch "${NODENV_ROOT}/versions/hello"
 
   run nodenv-versions --bare
-  assert_success "1.9"
+  assert_success
+  assert_output "1.9"
 }
 
 @test "lists symlinks under versions" {

--- a/test/whence.bats
+++ b/test/whence.bats
@@ -22,6 +22,6 @@ create_executable() {
 OUT
 
   run nodenv-whence npm
-  assert_success "1.8"
-
+  assert_success
+  assert_output "1.8"
 }

--- a/test/which.bats
+++ b/test/which.bats
@@ -63,25 +63,29 @@ create_executable() {
   touch kill-all-humans
   chmod +x kill-all-humans
   NODENV_VERSION=system run nodenv-which kill-all-humans
-  assert_failure "nodenv: kill-all-humans: command not found"
+  assert_failure
+  assert_output "nodenv: kill-all-humans: command not found"
 }
 
 @test "version not installed" {
   create_executable "2.0" "npm"
   NODENV_VERSION=1.9 run nodenv-which npm
-  assert_failure "nodenv: version \`1.9' is not installed (set by NODENV_VERSION environment variable)"
+  assert_failure
+  assert_output "nodenv: version \`1.9' is not installed (set by NODENV_VERSION environment variable)"
 }
 
 @test "no executable found" {
   create_executable "1.8" "npm"
   NODENV_VERSION=1.8 run nodenv-which node
-  assert_failure "nodenv: node: command not found"
+  assert_failure
+  assert_output "nodenv: node: command not found"
 }
 
 @test "no executable found for system version" {
   export PATH="$(path_without "mocha")"
   NODENV_VERSION=system run nodenv-which mocha
-  assert_failure "nodenv: mocha: command not found"
+  assert_failure
+  assert_output "nodenv: mocha: command not found"
 }
 
 @test "executable found in other versions" {

--- a/test/which.bats
+++ b/test/which.bats
@@ -17,10 +17,12 @@ create_executable() {
   create_executable "2.0" "npm"
 
   NODENV_VERSION=1.8 run nodenv-which node
-  assert_success "${NODENV_ROOT}/versions/1.8/bin/node"
+  assert_success
+  assert_output "${NODENV_ROOT}/versions/1.8/bin/node"
 
   NODENV_VERSION=2.0 run nodenv-which npm
-  assert_success "${NODENV_ROOT}/versions/2.0/bin/npm"
+  assert_success
+  assert_output "${NODENV_ROOT}/versions/2.0/bin/npm"
 }
 
 @test "searches PATH for system version" {
@@ -28,7 +30,8 @@ create_executable() {
   create_executable "${NODENV_ROOT}/shims" "kill-all-humans"
 
   NODENV_VERSION=system run nodenv-which kill-all-humans
-  assert_success "${NODENV_TEST_DIR}/bin/kill-all-humans"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/bin/kill-all-humans"
 }
 
 @test "searches PATH for system version (shims prepended)" {
@@ -36,7 +39,8 @@ create_executable() {
   create_executable "${NODENV_ROOT}/shims" "kill-all-humans"
 
   PATH="${NODENV_ROOT}/shims:$PATH" NODENV_VERSION=system run nodenv-which kill-all-humans
-  assert_success "${NODENV_TEST_DIR}/bin/kill-all-humans"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/bin/kill-all-humans"
 }
 
 @test "searches PATH for system version (shims appended)" {
@@ -44,7 +48,8 @@ create_executable() {
   create_executable "${NODENV_ROOT}/shims" "kill-all-humans"
 
   PATH="$PATH:${NODENV_ROOT}/shims" NODENV_VERSION=system run nodenv-which kill-all-humans
-  assert_success "${NODENV_TEST_DIR}/bin/kill-all-humans"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/bin/kill-all-humans"
 }
 
 @test "searches PATH for system version (shims spread)" {
@@ -53,7 +58,8 @@ create_executable() {
 
   PATH="${NODENV_ROOT}/shims:${NODENV_ROOT}/shims:/tmp/non-existent:$PATH:${NODENV_ROOT}/shims" \
     NODENV_VERSION=system run nodenv-which kill-all-humans
-  assert_success "${NODENV_TEST_DIR}/bin/kill-all-humans"
+  assert_success
+  assert_output "${NODENV_TEST_DIR}/bin/kill-all-humans"
 }
 
 @test "doesn't include current directory in PATH search" {
@@ -125,5 +131,6 @@ SH
   cd "$NODENV_TEST_DIR"
 
   NODENV_VERSION= run nodenv-which node
-  assert_success "${NODENV_ROOT}/versions/1.8/bin/node"
+  assert_success
+  assert_output "${NODENV_ROOT}/versions/1.8/bin/node"
 }


### PR DESCRIPTION
exploratory PR trying out https://github.com/ztombol/bats-assert

Actually using the new bats-assert is blocked by tagged releases of both bats-core and bats-assert (https://github.com/ztombol/bats-assert/issues/3) as well as npm-compatible package.json files (https://github.com/ztombol/bats-core/pull/2)

Would also prefer `refute` to be added before merging: https://github.com/ztombol/bats-assert/issues/4
