### PR TITLE
Set `PATH` to include the current Node.js bin/ for `system` too

### DIFF
--- a/libexec/nodenv-exec
+++ b/libexec/nodenv-exec
@@ -41,7 +41,5 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-if [ "$NODENV_VERSION" != "system" ]; then
-  export PATH="${NODENV_BIN_PATH}:${PATH}"
-fi
+export PATH="${NODENV_BIN_PATH}:${PATH}"
 exec -a "$NODENV_COMMAND" "$NODENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Add the current Node.js bin/ path to `PATH`, even if the Node.js version is set to `system`. This makes it consistent with the other cases, so that `node` and `npm` always refer to the actual executables within subprocesses of the invoked command.

I don’t know the reasons for why this “special case” handling exists, and it probably made sense to someone, but the inconsistency here is somewhat confusing. Feel completely free to reject this PR if you don’t like it. :smile:
