### PR TITLE
Ignore default-packages file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /src/Makefile
 /src/*.o
 /node_modules
+/default-packages

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 /src/Makefile
 /src/*.o
 /node_modules
+
+# from nodenv-default-packages plugin: https://github.com/nodenv/nodenv-default-packages
 /default-packages


### PR DESCRIPTION
Ignore the required `$(nodenv root)/default-packages` file used by [nodenv-default-packages](https://github.com/nodenv/nodenv-default-packages).

I prefixed the added line with a slash to follow the convention, but I normally would have omitted it. Let me know if you want it removed.
