### PR TITLE
autoload instructions suggests right login startup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ easy to fork and contribute any changes back upstream.
     $ echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.bash_profile
     ~~~
 
-    **Ubuntu Desktop note**: Modify your `~/.bashrc` instead of `~/.bash_profile`.
+    **Note:** Replace `.bash_profile` with `.bash_login` or `.profile` depending on [your login startup file](https://linux.die.net/man/1/bash).
 
     **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
 

--- a/libexec/nodenv-init
+++ b/libexec/nodenv-init
@@ -45,10 +45,12 @@ root="${0%/*}/.."
 if [ -z "$print" ]; then
   case "$shell" in
   bash )
-    if [ -f "${HOME}/.bashrc" ] && [ ! -f "${HOME}/.bash_profile" ]; then
-      profile='~/.bashrc'
+    if [ -f "${HOME}/.bash_profile" ]; then
+        profile='~/.bash_profile'
+    elif [ -f "${HOME}/.bash_login" ]; then
+        profile='~/.bash_login'
     else
-      profile='~/.bash_profile'
+      profile='~/.profile'
     fi
     ;;
   zsh )

--- a/test/init.bats
+++ b/test/init.bats
@@ -106,3 +106,19 @@ OUT
   assert_line '  switch "$command"'
   refute_line '  case "$command" in'
 }
+
+@test "autoload instructions for bash login startup scripts" {
+  mkdir -p "$HOME"
+  touch "$HOME/.profile"
+  run nodenv-init
+  assert_failure
+  assert_line "# the following to ~/.profile:"
+  touch "$HOME/.bash_login"
+  run nodenv-init
+  assert_failure
+  assert_line "# the following to ~/.bash_login:"
+  touch "$HOME/.bash_profile"
+  run nodenv-init
+  assert_failure
+  assert_line "# the following to ~/.bash_profile:"
+}


### PR DESCRIPTION
for bash, login startup file is now suggested based on existence of
~/.bash_profile, ~/.bash_login, ~/.profile in that order as checked
by bash.