### PR TITLE
Prefer 'set' command to 'setenv' function for fish shell

### DIFF
--- a/libexec/nodenv-init
+++ b/libexec/nodenv-init
@@ -86,8 +86,8 @@ mkdir -p "${NODENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
-  echo "setenv NODENV_SHELL $shell"
+  echo "set -gx PATH '${NODENV_ROOT}/shims' \$PATH"
+  echo "set -gx NODENV_SHELL $shell"
 ;;
 * )
   echo 'export PATH="'${NODENV_ROOT}'/shims:${PATH}"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -73,7 +73,7 @@ OUT
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run nodenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${NODENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
@@ -87,7 +87,7 @@ OUT
   export PATH="${NODENV_ROOT}/shims:$PATH"
   run nodenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${NODENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${NODENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {


### PR DESCRIPTION
The `setenv` function in fish shell has changed in fish-shell/fish-shell@75600b6.

This function in `libexec/nodenv-init` produces `setenv: Too many arguments` error.
We should use `set` command with `-gx` option.
