### PR TITLE
Handle version aliases within an lts directory

### DIFF
--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -97,13 +97,17 @@ while read -r version; do
 done < <(
   {
     shopt -s nullglob
-    for path in "$versions_dir"/*; do
+    for path in "$versions_dir"/* "$versions_dir"/lts/*; do
       if [ -d "$path" ]; then
+        if [ "$(basename "$path")" == "lts" ]; then
+          continue
+        fi
+
         if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
           target="$(realpath "$path")"
           [ "${target%/*}" != "$versions_dir" ] || continue
         fi
-        echo "${path##*/}"
+        echo "${path#"${versions_dir}/"}"
       fi
     done
     shopt -u nullglob


### PR DESCRIPTION
In combination with https://github.com/nodenv/nodenv-aliases/pull/25, this PR should allow for the ability to make and view aliases in the form of `lts/*`. This should increase the compatibility of auto-switching to `nvm`-style versions (e.g. `lts/carbon`).