### PR TITLE
nodenv-version learns to describe aliases

### DIFF
--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -8,4 +8,15 @@
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
-echo "$(nodenv-version-name) (set by $(nodenv-version-origin))"
+VERSION_NAME="$(nodenv-version-name)"
+VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
+
+if [ -L "$VERSION_PATH" ]; then
+  READLINK=$(type -p greadlink readlink | head -1)
+
+  if [ -n "$READLINK" ]; then
+    ALIAS=$(basename "$($READLINK "$VERSION_PATH")")
+  fi
+fi
+
+echo "$VERSION_NAME ${ALIAS+=> $ALIAS }(set by $(nodenv-version-origin))"

--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -14,13 +14,14 @@ VERSION_NAME="$(nodenv-version-name)"
 if [ "$VERSION_NAME" != system ]; then
   VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
 
-  if [ -L "$VERSION_PATH" ]; then
+  while [ -L "$VERSION_PATH" ]; do
     READLINK=$(type -p greadlink readlink | head -1)
 
     if [ -n "$READLINK" ]; then
-      ALIAS=$(basename "$($READLINK "$VERSION_PATH")")
+      VERSION_PATH=$($READLINK "$VERSION_PATH")
+      ALIAS=$(basename "$VERSION_PATH")
     fi
-  fi
+  done
 fi
 
 echo "$VERSION_NAME ${ALIAS+=> $ALIAS }(set by $(nodenv-version-origin))"

--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -9,13 +9,17 @@ set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
 VERSION_NAME="$(nodenv-version-name)"
-VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
 
-if [ -L "$VERSION_PATH" ]; then
-  READLINK=$(type -p greadlink readlink | head -1)
+# TODO figure out why travis requires this
+if [ "$VERSION_NAME" != system ]; then
+  VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
 
-  if [ -n "$READLINK" ]; then
-    ALIAS=$(basename "$($READLINK "$VERSION_PATH")")
+  if [ -L "$VERSION_PATH" ]; then
+    READLINK=$(type -p greadlink readlink | head -1)
+
+    if [ -n "$READLINK" ]; then
+      ALIAS=$(basename "$($READLINK "$VERSION_PATH")")
+    fi
   fi
 fi
 

--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -16,11 +16,10 @@ if [ "$VERSION_NAME" != system ]; then
 
   while [ -L "$VERSION_PATH" ]; do
     READLINK=$(type -p greadlink readlink | head -1)
+    [ -n "$READLINK" ] || break
 
-    if [ -n "$READLINK" ]; then
-      VERSION_PATH=$($READLINK "$VERSION_PATH")
-      ALIAS=$(basename "$VERSION_PATH")
-    fi
+    VERSION_PATH=$($READLINK "$VERSION_PATH")
+    ALIAS=$(basename "$VERSION_PATH")
   done
 fi
 

--- a/test/version.bats
+++ b/test/version.bats
@@ -18,6 +18,16 @@ setup() {
   assert_output "system (set by ${NODENV_ROOT}/version)"
 }
 
+@test "using a symlink/alias" {
+  create_version "1.9.3"
+  ln -sf "$NODENV_ROOT/versions/1.9.3" "$NODENV_ROOT/versions/1.9"
+
+  NODENV_VERSION=1.9 run nodenv-version
+
+  assert_success
+  assert_output "1.9 => 1.9.3 (set by NODENV_VERSION environment variable)"
+}
+
 @test "set by NODENV_VERSION" {
   create_version "1.9.3"
   NODENV_VERSION=1.9.3 run nodenv-version

--- a/test/version.bats
+++ b/test/version.bats
@@ -32,6 +32,17 @@ setup() {
   assert_output "1.9 => 1.9.3 (set by NODENV_VERSION environment variable)"
 }
 
+@test "links to links resolve the final target" {
+  create_version 1.9.3
+  alias_version 1.9 1.9.3
+  alias_version 1 1.9
+
+  NODENV_VERSION=1 run nodenv-version
+
+  assert_success
+  assert_output "1 => 1.9.3 (set by NODENV_VERSION environment variable)"
+}
+
 @test "set by NODENV_VERSION" {
   create_version "1.9.3"
   NODENV_VERSION=1.9.3 run nodenv-version

--- a/test/version.bats
+++ b/test/version.bats
@@ -6,6 +6,10 @@ create_version() {
   mkdir -p "${NODENV_ROOT}/versions/$1"
 }
 
+alias_version() {
+  ln -sf "$NODENV_ROOT/versions/$2" "$NODENV_ROOT/versions/$1"
+}
+
 setup() {
   mkdir -p "$NODENV_TEST_DIR"
   cd "$NODENV_TEST_DIR"
@@ -19,8 +23,8 @@ setup() {
 }
 
 @test "using a symlink/alias" {
-  create_version "1.9.3"
-  ln -sf "$NODENV_ROOT/versions/1.9.3" "$NODENV_ROOT/versions/1.9"
+  create_version 1.9.3
+  alias_version 1.9 1.9.3
 
   NODENV_VERSION=1.9 run nodenv-version
 


### PR DESCRIPTION
When printing the current node version and its origin (how it was set),
nodenv-version now resolves any symlinks to determine the final
targeted version.

It prints the version name as selected, an arrow and the aliased version
name, and finally the origin.
If the version is not an alias, the output is the same as before.

This only affects the output of `nodenv version`;
`nodenv-version-name` and `nodenv-version-origin` are unaffected.

before:
```
$ NODENV_VERSION=8 nodenv version
8 (set by NODENV_VERSION environment variable)
```

after:
```
$ NODENV_VERSION=8 nodenv version
8 => 8.9.1 (set by NODENV_VERSION environment variable)
```

closes #123