### PR TITLE
Figure out why 'system' node is borked on travis

### DIFF
--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -9,18 +9,14 @@ set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
 VERSION_NAME="$(nodenv-version-name)"
+VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
 
-# TODO figure out why travis requires this
-if [ "$VERSION_NAME" != system ]; then
-  VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
+while [ -L "$VERSION_PATH" ]; do
+  READLINK=$(type -p greadlink readlink | head -1)
+  [ -n "$READLINK" ] || break
 
-  while [ -L "$VERSION_PATH" ]; do
-    READLINK=$(type -p greadlink readlink | head -1)
-    [ -n "$READLINK" ] || break
-
-    VERSION_PATH=$($READLINK "$VERSION_PATH")
-    ALIAS=$(basename "$VERSION_PATH")
-  done
-fi
+  VERSION_PATH=$($READLINK "$VERSION_PATH")
+  ALIAS=$(basename "$VERSION_PATH")
+done
 
 echo "$VERSION_NAME ${ALIAS+=> $ALIAS }(set by $(nodenv-version-origin))"

--- a/libexec/nodenv-version
+++ b/libexec/nodenv-version
@@ -9,7 +9,7 @@ set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
 VERSION_NAME="$(nodenv-version-name)"
-VERSION_PATH="$(nodenv-prefix "$VERSION_NAME")"
+VERSION_PATH="$(nodenv-prefix "$VERSION_NAME" 2>/dev/null || true)"
 
 while [ -L "$VERSION_PATH" ]; do
   READLINK=$(type -p greadlink readlink | head -1)


### PR DESCRIPTION
nodenv prefix system blows up on travis with "node: command not found"