### PR TITLE
Remove test-only abort messages

### DIFF
--- a/libexec/nodenv
+++ b/libexec/nodenv
@@ -26,8 +26,6 @@ if enable -f "${BASH_SOURCE%/*}"/../libexec/nodenv-realpath.dylib realpath 2>/de
     echo "${path%/*}"
   }
 else
-  [ -z "$NODENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
-
   READLINK=$(type -p greadlink readlink | head -1)
   [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 

--- a/libexec/nodenv-hooks
+++ b/libexec/nodenv-hooks
@@ -22,34 +22,30 @@ if [ -z "$NODENV_COMMAND" ]; then
 fi
 
 if ! enable -f "${BASH_SOURCE%/*}"/nodenv-realpath.dylib realpath 2>/dev/null; then
-  if [ -n "$NODENV_NATIVE_EXT" ]; then
-    echo "nodenv: failed to load \`realpath' builtin" >&2
+  READLINK=$(type -p greadlink readlink | head -1)
+  if [ -z "$READLINK" ]; then
+    echo "nodenv: cannot find readlink - are you missing GNU coreutils?" >&2
     exit 1
   fi
-READLINK=$(type -p greadlink readlink | head -1)
-if [ -z "$READLINK" ]; then
-  echo "nodenv: cannot find readlink - are you missing GNU coreutils?" >&2
-  exit 1
-fi
 
-resolve_link() {
-  $READLINK "$1"
-}
+  resolve_link() {
+    $READLINK "$1"
+  }
 
-realpath() {
-  local cwd="$PWD"
-  local path="$1"
-  local name
+  realpath() {
+    local cwd="$PWD"
+    local path="$1"
+    local name
 
-  while [ -n "$path" ]; do
-    name="${path##*/}"
-    [ "$name" = "$path" ] || cd "${path%/*}"
-    path="$(resolve_link "$name" || true)"
-  done
+    while [ -n "$path" ]; do
+      name="${path##*/}"
+      [ "$name" = "$path" ] || cd "${path%/*}"
+      path="$(resolve_link "$name" || true)"
+    done
 
-  echo "${PWD}/$name"
-  cd "$cwd"
-}
+    echo "${PWD}/$name"
+    cd "$cwd"
+  }
 fi
 
 IFS=: hook_paths=($NODENV_HOOK_PATH)

--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -28,11 +28,6 @@ done
 versions_dir="${NODENV_ROOT}/versions"
 
 if ! enable -f "${BASH_SOURCE%/*}"/nodenv-realpath.dylib realpath 2>/dev/null; then
-  if [ -n "$NODENV_NATIVE_EXT" ]; then
-    echo "nodenv: failed to load \`realpath' builtin" >&2
-    exit 1
-  fi
-
   READLINK=$(type -p greadlink readlink | head -1)
   if [ -z "$READLINK" ]; then
     echo "nodenv: cannot find readlink - are you missing GNU coreutils?" >&2

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -10,10 +10,12 @@ if [ -z "$NODENV_TEST_DIR" ]; then
   NODENV_TEST_DIR="$(mktemp -d "${NODENV_TEST_DIR}.XXX" 2>/dev/null || echo "$NODENV_TEST_DIR")"
   export NODENV_TEST_DIR
 
-  if enable -f "${BATS_TEST_DIRNAME}"/../libexec/nodenv-realpath.dylib realpath 2>/dev/null; then
+  NODENV_REALPATH=$BATS_TEST_DIRNAME/../libexec/nodenv-realpath.dylib
+
+  if enable -f "$NODENV_REALPATH" realpath 2>/dev/null; then
     NODENV_TEST_DIR="$(realpath "$NODENV_TEST_DIR")"
   else
-    if [ -n "$NODENV_NATIVE_EXT" ]; then
+    if [ -x "$NODENV_REALPATH" ]; then
       echo "nodenv: failed to load \`realpath' builtin" >&2
       exit 1
     fi


### PR DESCRIPTION
These messages are only printed if NODENV_NATIVE_EXT is set; and it _was_ only
set for test runs. (It is not expected to be set by users.) Thus these
messages are only useful when running on travis, and I'd rather there not
be test-only code running for users.

Also, update the test helper to not use the NODENV_NATIVE_EXT variable
at all, since the travis config no longer uses it. (We build the native
extension as part of npm-install, and have an extra travis job that
immediately removes the compiled executable. Thus, it either exists or
doesn't, for a given test run. There is no variable that declares its
existence.) Instead, just check for the existence of the extension; if
it exists, we should assume it was attempted to be enabled and fail if
accordingly.