### PR TITLE
Migrate from old bats libs

### DIFF
--- a/test/completions.bats
+++ b/test/completions.bats
@@ -27,7 +27,7 @@ else
 fi"
   run nodenv-completions hello
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 --help
 hello
 OUT
@@ -44,7 +44,7 @@ else
 fi"
   run nodenv-completions hello happy world
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 --help
 happy
 world

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -38,7 +38,7 @@ create_executable() {
   nodenv-rehash
   run nodenv-completions exec
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 --help
 node
 npm
@@ -70,7 +70,7 @@ SH
 
   run nodenv-exec node -w "/path to/node script.rb" -- extra args
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 ${NODENV_ROOT}/versions/2.0/bin/node
   -w
   /path to/node script.rb

--- a/test/help.bats
+++ b/test/help.bats
@@ -27,7 +27,7 @@ SH
 
   run nodenv-help hello
   assert_success
-  assert_output <<SH
+  assert_output - <<SH
 Usage: nodenv hello <world>
 
 This command is useful for saying hello.
@@ -45,7 +45,7 @@ SH
 
   run nodenv-help hello
   assert_success
-  assert_output <<SH
+  assert_output - <<SH
 Usage: nodenv hello <world>
 
 Says "hello" to you, from nodenv
@@ -81,7 +81,7 @@ SH
 
   run nodenv-help hello
   assert_success
-  assert_output <<SH
+  assert_output - <<SH
 Usage: nodenv hello <world>
        nodenv hi [everybody]
        nodenv hola --translate
@@ -106,7 +106,7 @@ SH
 
   run nodenv-help hello
   assert_success
-  assert_output <<SH
+  assert_output - <<SH
 Usage: nodenv hello <world>
 
 This is extended help text.

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -21,7 +21,7 @@ load test_helper
 
   NODENV_HOOK_PATH="$path1:$path2" run nodenv-hooks exec
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 ${NODENV_TEST_DIR}/nodenv.d/exec/ahoy.bash
 ${NODENV_TEST_DIR}/nodenv.d/exec/hello.bash
 ${NODENV_TEST_DIR}/etc/nodenv_hooks/exec/bueno.bash
@@ -38,7 +38,7 @@ OUT
 
   NODENV_HOOK_PATH="$path1:$path2" run nodenv-hooks exec
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 ${NODENV_TEST_DIR}/my hooks/nodenv.d/exec/hello.bash
 ${NODENV_TEST_DIR}/etc/nodenv hooks/exec/ahoy.bash
 OUT
@@ -65,7 +65,7 @@ OUT
 
   NODENV_HOOK_PATH="$path" run nodenv-hooks exec
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 ${HOME}/hola.bash
 ${NODENV_TEST_DIR}/nodenv.d/exec/bright.sh
 OUT

--- a/test/init.bats
+++ b/test/init.bats
@@ -53,7 +53,7 @@ OUT
 
 @test "fish instructions" {
   run nodenv-init fish
-  assert [ "$status" -eq 1 ]
+  assert_failure 1
   assert_line 'status --is-interactive; and source (nodenv init -|psub)'
 }
 

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -43,8 +43,8 @@ OUT
 @test "prefix for invalid system" {
   PATH="$(path_without node)" run nodenv-prefix system
   assert_failure
-  assert_output <<EOF
+  assert_output - <<EOF
 nodenv: node: command not found
-nodenv: system version not found in PATH"
+nodenv: system version not found in PATH
 EOF
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -49,7 +49,7 @@ create_executable() {
 
   run ls "${NODENV_ROOT}/shims"
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 node
 npm
 OUT
@@ -103,7 +103,7 @@ OUT
 
   run ls "${NODENV_ROOT}/shims"
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 node
 npm
 OUT

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -51,7 +51,7 @@ load test_helper
 @test "shell unset" {
   NODENV_SHELL=bash run nodenv-sh-shell --unset
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 NODENV_VERSION_OLD="\$NODENV_VERSION"
 unset NODENV_VERSION
 OUT
@@ -60,7 +60,7 @@ OUT
 @test "shell unset (fish)" {
   NODENV_SHELL=fish run nodenv-sh-shell --unset
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 set -gu NODENV_VERSION_OLD "\$NODENV_VERSION"
 set -e NODENV_VERSION
 OUT
@@ -69,7 +69,7 @@ OUT
 @test "shell change invalid version" {
   run nodenv-sh-shell 1.2.3
   assert_failure
-  assert_output <<SH
+  assert_output - <<SH
 nodenv: version \`1.2.3' not installed
 false
 SH
@@ -79,7 +79,7 @@ SH
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   NODENV_SHELL=bash run nodenv-sh-shell 1.2.3
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 NODENV_VERSION_OLD="\$NODENV_VERSION"
 export NODENV_VERSION="1.2.3"
 OUT
@@ -89,7 +89,7 @@ OUT
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"
   NODENV_SHELL=fish run nodenv-sh-shell 1.2.3
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 set -gu NODENV_VERSION_OLD "\$NODENV_VERSION"
 set -gx NODENV_VERSION "1.2.3"
 OUT

--- a/test/shims.bats
+++ b/test/shims.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "no shims" {
   run nodenv-shims
   assert_success
-  assert [ -z "$output" ]
+  refute_output
 }
 
 @test "shims" {

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -43,7 +43,7 @@ stub_system_node() {
   create_version "1.9"
   run nodenv-versions
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 * system (set by ${NODENV_ROOT}/version)
   1.9
 OUT
@@ -63,7 +63,7 @@ OUT
   create_version "2.0.0"
   run nodenv-versions
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 * system (set by ${NODENV_ROOT}/version)
   1.8.7
   1.9.3
@@ -77,7 +77,7 @@ OUT
   create_version "2.0.0"
   NODENV_VERSION=1.9.3 run nodenv-versions
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
   system
 * 1.9.3 (set by NODENV_VERSION environment variable)
   2.0.0
@@ -89,7 +89,7 @@ OUT
   create_version "2.0.0"
   NODENV_VERSION=1.9.3 run nodenv-versions --bare
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 1.9.3
 2.0.0
 OUT
@@ -102,7 +102,7 @@ OUT
   cat > "${NODENV_ROOT}/version" <<<"1.9.3"
   run nodenv-versions
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
   system
 * 1.9.3 (set by ${NODENV_ROOT}/version)
   2.0.0
@@ -116,7 +116,7 @@ OUT
   cat > ".node-version" <<<"1.9.3"
   run nodenv-versions
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
   system
 * 1.9.3 (set by ${NODENV_TEST_DIR}/.node-version)
   2.0.0
@@ -138,7 +138,7 @@ OUT
 
   run nodenv-versions --bare
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 1.8
 1.8.7
 OUT
@@ -153,7 +153,7 @@ OUT
   run nodenv-versions --bare --skip-aliases
   assert_success
 
-  assert_output <<OUT
+  assert_output - <<OUT
 1.8.7
 1.9
 OUT

--- a/test/whence.bats
+++ b/test/whence.bats
@@ -16,7 +16,7 @@ create_executable() {
 
   run nodenv-whence node
   assert_success
-  assert_output <<OUT
+  assert_output - <<OUT
 1.8
 2.0
 OUT

--- a/test/which.bats
+++ b/test/which.bats
@@ -99,7 +99,7 @@ create_executable() {
 
   NODENV_VERSION=1.8 run nodenv-which npm
   assert_failure
-  assert_output <<OUT
+  assert_output - <<OUT
 nodenv: npm: command not found
 
 The \`npm' command exists in these Node versions:


### PR DESCRIPTION
specifically assert_output requires explicit argument to indicate STDIN