### PR TITLE
Adds an exec hook to handle npx specially

### DIFF
--- a/nodenv.d/exec/npx.bash
+++ b/nodenv.d/exec/npx.bash
@@ -1,0 +1,21 @@
+# If npx is being executed, remove nodenv's shims from PATH
+# such that npx won't find the shims for executables that
+# only exist in non-active nodes.
+# This ensures npx can install the necessary package on-demand.
+
+[ "$NODENV_COMMAND" = npx ] || return 0
+
+remove_from_path() {
+  local path_to_remove="$1"
+  local path_before
+  local result=":${PATH//\~/$HOME}:"
+  while [ "$path_before" != "$result" ]; do
+    path_before="$result"
+    result="${result//:$path_to_remove:/:}"
+  done
+  result="${result%:}"
+  echo "${result#:}"
+}
+
+PATH="$(remove_from_path "${NODENV_ROOT}/shims")"
+export PATH

--- a/test/npx.bats
+++ b/test/npx.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+create_executable() {
+  name="${1?}"
+  shift 1
+  bin="${NODENV_ROOT}/versions/${NODENV_VERSION}/bin"
+  mkdir -p "$bin"
+  { if [ $# -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } | sed -Ee '1s/^ +//' > "${bin}/$name"
+  chmod +x "${bin}/$name"
+}
+
+@test "shims are removed from PATH when executing npx" {
+  # emulate npx to look for existing bin
+  NODENV_VERSION=8.0 create_executable "npx" <<SH
+#!$BASH
+exec which -a \$1
+SH
+
+  # bin available in other node version
+  NODENV_VERSION=6.0 create_executable "some_dummy_exe_that_wont_conflict" "#!/bin/sh"
+
+  nodenv-rehash
+
+  NODENV_VERSION=8.0 run nodenv-exec npx some_dummy_exe_that_wont_conflict
+
+  refute_output # fake npx just does 'which' and shouldn't find the dummy exe
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -23,8 +23,7 @@ if [ -z "$NODENV_TEST_DIR" ]; then
 
   export NODENV_ROOT="${NODENV_TEST_DIR}/root"
   export HOME="${NODENV_TEST_DIR}/home"
-  TEST_NODENV_HOOK_PATH="${NODENV_ROOT}/nodenv.d"
-  export NODENV_HOOK_PATH=$TEST_NODENV_HOOK_PATH:$BATS_TEST_DIRNAME/../nodenv.d
+  export NODENV_HOOK_PATH=$NODENV_ROOT/nodenv.d:$BATS_TEST_DIRNAME/../nodenv.d
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PATH="${NODENV_TEST_DIR}/bin:$PATH"
@@ -65,9 +64,10 @@ path_without() {
 }
 
 create_hook() {
-  mkdir -p "${TEST_NODENV_HOOK_PATH}/$1"
-  touch "${TEST_NODENV_HOOK_PATH}/$1/$2"
+  local hook_path=${NODENV_HOOK_PATH%%:*}
+  mkdir -p "${hook_path:?}/$1"
+  touch "${hook_path:?}/$1/$2"
   if [ ! -t 0 ]; then
-    cat > "${TEST_NODENV_HOOK_PATH}/$1/$2"
+    cat > "${hook_path:?}/$1/$2"
   fi
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -23,7 +23,8 @@ if [ -z "$NODENV_TEST_DIR" ]; then
 
   export NODENV_ROOT="${NODENV_TEST_DIR}/root"
   export HOME="${NODENV_TEST_DIR}/home"
-  export NODENV_HOOK_PATH="${NODENV_ROOT}/nodenv.d"
+  TEST_NODENV_HOOK_PATH="${NODENV_ROOT}/nodenv.d"
+  export NODENV_HOOK_PATH=$TEST_NODENV_HOOK_PATH:$BATS_TEST_DIRNAME/../nodenv.d
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PATH="${NODENV_TEST_DIR}/bin:$PATH"
@@ -64,9 +65,9 @@ path_without() {
 }
 
 create_hook() {
-  mkdir -p "${NODENV_HOOK_PATH}/$1"
-  touch "${NODENV_HOOK_PATH}/$1/$2"
+  mkdir -p "${TEST_NODENV_HOOK_PATH}/$1"
+  touch "${TEST_NODENV_HOOK_PATH}/$1/$2"
   if [ ! -t 0 ]; then
-    cat > "${NODENV_HOOK_PATH}/$1/$2"
+    cat > "${TEST_NODENV_HOOK_PATH}/$1/$2"
   fi
 }


### PR DESCRIPTION
If npx is being executed, remove nodenv's shims from PATH such that npx
won't find the shims for executables that only exist in non-active
nodes. This ensures npx can install the necessary package on-demand.

PR for #79 