### PR TITLE
Make --version more semver friendly

### DIFF
--- a/libexec/nodenv---version
+++ b/libexec/nodenv---version
@@ -5,7 +5,7 @@
 # current revision from git, if available.
 #
 # The format of the git revision is:
-#   <version>-<num_commits>-<git_sha>
+#   <version>+<num_commits>.<git_sha>
 # where `num_commits` is the number of commits since `version` was
 # tagged.
 
@@ -16,8 +16,12 @@ cd "${BASH_SOURCE%/*}" 2>/dev/null
 
 version=1.2.0
 
+semver_compliant() {
+  sed -E 's/-([[:digit:]]+)-g([[:alnum:]]+)/+\1.\2/'
+}
+
 if git remote -v 2>/dev/null | grep -q nodenv; then
-  git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
+  git_revision="$(git describe --tags HEAD 2>/dev/null | semver_compliant || true)"
   git_revision="${git_revision#v}"
 fi
 

--- a/test/--version.bats
+++ b/test/--version.bats
@@ -43,7 +43,7 @@ git_commit() {
 
   run nodenv---version
   assert_success
-  assert_output "nodenv 0.4.1-2-g$(git rev-parse --short HEAD)"
+  assert_output "nodenv 0.4.1+2.$(git rev-parse --short HEAD)"
 }
 
 @test "prints default version if no tags in git repo" {


### PR DESCRIPTION
The current output of nodenv --version is essentially the direct output
of git-describe, which is TAG-COMMITS_SINCE_TAG-gSHA.

The commits-since, and sha segments would be considered build metadata
in semver parlance.

This change tweaks the output of git-describe such that it is in a
semver compliant format; despite not strictly being semver compliant in
semantics. (Which isn't really possible with edge/HEAD anyway)

It also eliminates the "g" prefix which is used to denote the sha
references the git SCM.

before/after:
```diff
$ nodenv --version
-nodenv 1.2.0-30-gd57082d
+nodenv 1.2.0+30.d57082d
```