### PR TITLE
Handle version aliases within an lts directory (replaces #118)

### DIFF
--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -99,9 +99,7 @@ done < <(
     shopt -s nullglob
     for path in "$versions_dir"/* "$versions_dir"/lts/*; do
       if [ -d "$path" ]; then
-        if [[ $path =~ /lts(/bin)?$ && ! -L $path ]]; then
-          continue
-        fi
+        if [ ! -d "$path/bin" ]; then continue; fi
 
         if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
           target="$(realpath "$path")"

--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -99,7 +99,7 @@ done < <(
     shopt -s nullglob
     for path in "$versions_dir"/* "$versions_dir"/lts/*; do
       if [ -d "$path" ]; then
-        if [ "$(basename "$path")" == "lts" ]; then
+        if [[ $path =~ /lts(/bin)?$ && ! -L $path ]]; then
           continue
         fi
 

--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -97,13 +97,17 @@ while read -r version; do
 done < <(
   {
     shopt -s nullglob
-    for path in "$versions_dir"/*; do
+    for path in "$versions_dir"/* "$versions_dir"/lts/*; do
       if [ -d "$path" ]; then
+        if [ "$(basename "$path")" == "lts" ]; then
+          continue
+        fi
+
         if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
           target="$(realpath "$path")"
           [ "${target%/*}" != "$versions_dir" ] || continue
         fi
-        echo "${path##*/}"
+        echo "${path#"${versions_dir}/"}"
       fi
     done
     shopt -u nullglob

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -116,7 +116,7 @@ OUT
 OUT
 }
 
-@test "indicates current version when using lts alias" {
+@test "indicates current version when using lts/<codename> alias" {
   stub_system_node
   create_version "1.9.3"
   create_version "2.0.0"
@@ -131,6 +131,23 @@ OUT
   1.9.3
   2.0.0
 * lts/bar => 1.9.3 (set by NODENV_VERSION environment variable)
+OUT
+}
+
+@test "indicates current version when using lts as a direct alias" {
+  stub_system_node
+  create_version "1.9.3"
+  create_version "2.0.0"
+  ln -s "./1.9.3" "${NODENV_ROOT}/versions/lts"
+
+  NODENV_VERSION=lts run nodenv-versions
+
+  assert_success
+  assert_output - <<OUT
+  system
+  1.9.3
+  2.0.0
+* lts => 1.9.3 (set by NODENV_VERSION environment variable)
 OUT
 }
 

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -116,52 +116,14 @@ OUT
 OUT
 }
 
-@test "indicates current version when using lts/<codename> alias" {
-  stub_system_node
-  create_version "1.9.3"
-  create_version "2.0.0"
-  mkdir "${NODENV_ROOT}/versions/lts"
-  ln -s "../1.9.3" "${NODENV_ROOT}/versions/lts/bar"
-
-  NODENV_VERSION=lts/bar run nodenv-versions
-
-  assert_success
-  assert_output - <<OUT
-  system
-  1.9.3
-  2.0.0
-* lts/bar => 1.9.3 (set by NODENV_VERSION environment variable)
-OUT
-}
-
-@test "indicates current version when using lts as a direct alias" {
-  stub_system_node
-  create_version "1.9.3"
-  create_version "2.0.0"
-  ln -s "./1.9.3" "${NODENV_ROOT}/versions/lts"
-
-  NODENV_VERSION=lts run nodenv-versions
-
-  assert_success
-  assert_output - <<OUT
-  system
-  1.9.3
-  2.0.0
-* lts => 1.9.3 (set by NODENV_VERSION environment variable)
-OUT
-}
-
 @test "bare doesn't indicate current version" {
   create_version "1.9.3"
   create_version "2.0.0"
-  mkdir "${NODENV_ROOT}/versions/lts"
-  ln -s "../1.9.3" "${NODENV_ROOT}/versions/lts/bar"
   NODENV_VERSION=1.9.3 run nodenv-versions --bare
   assert_success
   assert_output - <<OUT
 1.9.3
 2.0.0
-lts/bar
 OUT
 }
 
@@ -193,23 +155,6 @@ OUT
 OUT
 }
 
-@test "per-project version when using lts alias" {
-  stub_system_node
-  create_version "1.9.3"
-  create_version "2.0.0"
-  mkdir "${NODENV_ROOT}/versions/lts"
-  ln -s "../1.9.3" "${NODENV_ROOT}/versions/lts/bar"
-  cat > ".node-version" <<<"lts/bar"
-  run nodenv-versions
-  assert_success
-  assert_output - <<OUT
-  system
-  1.9.3
-  2.0.0
-* lts/bar => 1.9.3 (set by ${NODENV_TEST_DIR}/.node-version)
-OUT
-}
-
 @test "ignores non-directories under versions" {
   create_version "1.9"
   touch "${NODENV_ROOT}/versions/hello"
@@ -223,21 +168,21 @@ OUT
   create_version "1.8.7"
   ln -s "1.8.7" "${NODENV_ROOT}/versions/1.8"
   mkdir "${NODENV_ROOT}/versions/lts"
-  ln -s "../1.8.7" "${NODENV_ROOT}/versions/lts/foo"
+  ln -s "../1.8.7" "${NODENV_ROOT}/versions/lts/argon"
 
   run nodenv-versions --bare
   assert_success
   assert_output - <<OUT
 1.8
 1.8.7
-lts/foo
+lts/argon
 OUT
 }
 
 @test "doesn't list symlink aliases when --skip-aliases" {
   create_version "1.8.7"
   ln -s "1.8.7" "${NODENV_ROOT}/versions/1.8"
-  mkdir moo
+  mkdir -p moo/bin
   ln -s "${PWD}/moo" "${NODENV_ROOT}/versions/1.9"
 
   run nodenv-versions --bare --skip-aliases
@@ -246,5 +191,64 @@ OUT
   assert_output - <<OUT
 1.8.7
 1.9
+OUT
+}
+
+@test "recurses into lts subdirectory" {
+  create_version "2.0.0"
+  mkdir "${NODENV_ROOT}/versions/lts"
+  create_version "lts/argon"
+  ln -s "../2.0.0" "${NODENV_ROOT}/versions/lts/boron"
+
+  NODENV_VERSION=2.0.0 run nodenv-versions
+
+  assert_success
+  assert_output - <<OUT
+  system
+* 2.0.0 (set by NODENV_VERSION environment variable)
+  lts/argon
+  lts/boron
+OUT
+}
+
+@test "does not recurse into non-lts subdirectories" {
+  create_version "2.0.0"
+  mkdir "${NODENV_ROOT}/versions/other"
+  create_version "other/1.2.3"
+
+  NODENV_VERSION=2.0.0 run nodenv-versions
+
+  assert_success
+  assert_output - <<OUT
+  system
+* 2.0.0 (set by NODENV_VERSION environment variable)
+OUT
+}
+
+@test "lists version named lts" {
+  create_version "2.0.0"
+  create_version "lts"
+
+  NODENV_VERSION=2.0.0 run nodenv-versions
+
+  assert_success
+  assert_output - <<OUT
+  system
+* 2.0.0 (set by NODENV_VERSION environment variable)
+  lts
+OUT
+}
+
+@test "lists alias named lts" {
+  create_version "2.0.0"
+  ln -s "2.0.0" "${NODENV_ROOT}/versions/lts"
+
+  NODENV_VERSION=2.0.0 run nodenv-versions
+
+  assert_success
+  assert_output - <<OUT
+  system
+* 2.0.0 (set by NODENV_VERSION environment variable)
+  lts
 OUT
 }


### PR DESCRIPTION
Closes #118 

This contains the feature changes from #118 plus some additional tests. Opening as a separate PR to make it easier to merge the combination of both.