### PR TITLE
Add ZPlug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ bulletproof deployments.
 - [Installation](#installation)
   * [Homebrew on macOS](#homebrew-on-macos)
     + [Upgrading with Homebrew](#upgrading-with-homebrew)
+  * [via ZPlug plugin manager for Zsh](#via-zplug-plugin-manager-for-zsh)
+    + [Upgrading with ZPlug](#upgrading-with-zplug)
   * [Basic GitHub Checkout](#basic-github-checkout)
     + [Upgrading with Git](#upgrading-with-git)
     + [Updating the list of available Node versions](#updating-the-list-of-available-node-versions)
@@ -202,6 +204,25 @@ Node versions, upgrade the Homebrew packages:
 $ brew upgrade nodenv node-build
 ~~~
 
+### via ZPlug plugin manager for Zsh
+Add the following line to your `.zshrc`:
+
+```zplug "RiverGlide/zsh-nodenv", from:gitlab```
+
+Then install the plugin
+~~~ zsh
+  $ source ~/.zshrc
+  $ zplug install
+~~~
+
+The ZPlug plugin will install and initialise `nodenv` and `node-build` and add `nodenv` and `nodenv-install` to your `PATH`
+
+#### Upgrading with ZPlug
+To update to the latest nodenv and update node-build with newly released
+Node versions, update the ZPlug plugin:
+~~~ sh
+$ zplug update RiverGlide/nodenv
+~~~
 
 ### Basic GitHub Checkout
 


### PR DESCRIPTION
This PR updates the documentation to include installation via ZPlug plugin.

The plugin at https://gitlab.com/RiverGlide/zsh-nodenv.git is pretty straightforward, and would be a good candidate for bringing under the nodenv organisation.
It uses git submodules to checkout nodenv and node-build, and the plugin file itself adds nodenv and nodenv-install to the path as well as calling eval $(nodenv init -)

For ZPlug users, this is a clean, portable, easy way to install