### PR TITLE
Handle case where `nodenv-commands --sh` returns nothing

### DIFF
--- a/libexec/nodenv-init
+++ b/libexec/nodenv-init
@@ -145,7 +145,7 @@ cat <<EOS
   fi
 
   case "\$command" in
-  ${commands[*]})
+  ${commands[*]:-/})
     eval "\$(nodenv "sh-\$command" "\$@")";;
   *)
     command nodenv "\$command" "\$@";;

--- a/test/init.bats
+++ b/test/init.bats
@@ -2,6 +2,18 @@
 
 load test_helper
 
+setup() {
+  export PATH="${NODENV_TEST_DIR}/bin:$PATH"
+}
+
+create_executable() {
+  local name="$1"
+  local bin="${NODENV_TEST_DIR}/bin"
+  mkdir -p "$bin"
+  sed -Ee '1s/^ +//' > "${bin}/$name"
+  chmod +x "${bin}/$name"
+}
+
 @test "creates shims and versions directories" {
   assert [ ! -d "${NODENV_ROOT}/shims" ]
   assert [ ! -d "${NODENV_ROOT}/versions" ]
@@ -106,6 +118,24 @@ OUT
   run nodenv-init - zsh
   assert_success
   assert_line '  case "$command" in'
+}
+
+@test "outputs sh-compatible case syntax" {
+  create_executable nodenv-commands <<!
+#!$BASH
+echo -e 'rehash\nshell'
+!
+  run nodenv-init - bash
+  assert_success
+  assert_line '  rehash|shell)'
+
+  create_executable nodenv-commands <<!
+#!$BASH
+echo
+!
+  run nodenv-init - bash
+  assert_success
+  assert_line '  /)'
 }
 
 @test "outputs fish-specific syntax (fish)" {


### PR DESCRIPTION
In exceptional cases (e.g., custom installation, malfunctions elsewhere), `nodenv-commands --sh` may return nothing. In non-Fish shells, this would cause "syntax error near unexpected token `)'" in `nodenv()`.

Bash does not allow one to specify a `case` option without a pattern. We work around it by defaulting to `/`. Commands, being filenames, can never match it. In Fish, nothing needs to be done: it apparently does interpret a `case` without an argument as one that never matches.

This patch is based on 02e1d4a[^1] from `pyenv`, which was written by @ native-api and I.

[^1]: https://github.com/pyenv/pyenv/commit/02e1d4a293139ecf2c94206ee9c00b388550366e

---

Feel free to edit the commit message as needed, but I would appreciate if you kept most of it. I sometimes find it useful to grep the Git logs when developing.

If you want to see some discussion about the original patch for `pyenv`, look at <https://github.com/pyenv/pyenv/pull/2908>.