### PR TITLE
Renamed master->main

### DIFF
--- a/.github/workflows/sync-default-branch.yml
+++ b/.github/workflows/sync-default-branch.yml
@@ -1,0 +1,18 @@
+name: Sync Default Branch
+on:
+  push: { branches: "main" }
+  workflow_dispatch:
+
+# One-time commands for users to switch-over:
+#
+# ```console
+# git branch -m master main
+# git fetch origin
+# git branch -u origin/main main
+# git remote set-head origin -a
+# ```
+
+jobs:
+  sync:
+    permissions: { contents: write }
+    uses: nodenv/.github/.github/workflows/sync-default-branch.yml@v3


### PR DESCRIPTION
Workflow to continue syncing master branch whenever main advances. This will prevent clones of this repo from breaking.