### PR TITLE
Fix npm pkg warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/nodenv/nodenv.git"
+    "url": "git+https://github.com/nodenv/nodenv.git"
   },
   "bugs": {
     "url": "https://github.com/nodenv/nodenv/issues"
@@ -21,7 +21,9 @@
     "src": "./src",
     "test": "./test"
   },
-  "bin": "./libexec/nodenv",
+  "bin": {
+    "nodenv": "libexec/nodenv"
+  },
   "files": [
     "completions",
     "libexec",
@@ -43,7 +45,7 @@
   },
   "devDependencies": {
     "bats": "^1.11.0",
-    "bats-assert": "jasonkarns/bats-assert-1",
-    "bats-support": "jasonkarns/bats-support"
+    "bats-assert": "github:jasonkarns/bats-assert-1",
+    "bats-support": "github:jasonkarns/bats-support"
   }
 }


### PR DESCRIPTION
npm-pkg-fix

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "bin" was converted to an object
npm WARN publish "bin[@nodenv/nodenv]" was renamed to "bin[nodenv]"
npm WARN publish "bin[nodenv]" script name was cleaned
npm WARN publish "repository.url" was normalized to "git+https://github.com/nodenv/nodenv.git"
npm WARN publish Normalized git reference to "devDependencies.bats-assert"
npm WARN publish Normalized git reference to "devDependencies.bats-support"
```