### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule: { interval: monthly }
+  - package-ecosystem: npm
+    directory: "/"
+    schedule: { interval: monthly }


### PR DESCRIPTION
depfu has been fantastic for org-wide configuration without needing a
config file in _each and every_ repo.

(And also, depfu's "burn-in" feature is super nice.)

But depfu doesn't handle github actions bumping and that's more than
half of the deps we need to manage.
