### PR TITLE
Move rbenv tags to rbtags namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ The configuration assumes nodenv's remote is `origin`, and rbenv's remote is `rb
 
    **Beware:** the `--tags` option to `fetch` et. al. will override this setting.
 
-2. Fetch rbenv's tags to their own refspec namespace (`rbenv-tags`, in this case):
+2. Fetch rbenv's tags to their own refspec namespace (`rbtags`, in this case):
 
-        git config --add remote.rbenv.fetch '+refs/tags/*:refs/rbenv-tags/*'
+        git config --add remote.rbenv.fetch '+refs/tags/*:refs/rbtags/*'
 
 
 Resulting snippet in `.git/config`:
@@ -28,13 +28,13 @@ Resulting snippet in `.git/config`:
 [remote "rbenv"]
 	url = git@github.com:rbenv/rbenv.git
 	fetch = +refs/heads/*:refs/remotes/rbenv/*
-	fetch = +refs/tags/*:refs/rbenv-tags/*
+	fetch = +refs/tags/*:refs/rbtags/*
 	tagopt = --no-tags
 ```
 
-To reference rbenv's tags, use the fully qualified refspec: `refs/rbenv-tags/vX.Y.Z`
+To reference rbenv's tags, use the fully qualified refspec: `refs/rbtags/vX.Y.Z`
 
-    git show refs/rbenv-tags/v1.1.2
-    git checkout refs/rbenv-tags/v1.1.2
-    git merge refs/rbenv-tags/v1.1.2
+    git show refs/rbtags/v1.1.2
+    git checkout refs/rbtags/v1.1.2
+    git merge refs/rbtags/v1.1.2
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "preversion": "script/preversion",
     "version": "script/sync-version",
     "postversion": "git push --follow-tags",
-    "behind-rbenv": "git for-each-ref refs/rbenv-tags --format='%(refname)' --no-merged"
+    "behind-rbenv": "git for-each-ref refs/rbtags --format='%(refname)' --no-merged"
   },
   "devDependencies": {
     "bats": "^1.12.0",


### PR DESCRIPTION
using `rbtags` since it's shorter and doesn't distinguish between rbenv and ruby-build (since we also use this at node-build).