### PR TITLE
Resolve partial versions in .node-version to latest installed match

### DIFF
--- a/libexec/nodenv-sh-shell
+++ b/libexec/nodenv-sh-shell
@@ -120,25 +120,27 @@ EOS
   exit
 fi
 
-# Make sure the specified version is installed.
-if nodenv-prefix "$version" >/dev/null; then
-  if [ "$version" != "$NODENV_VERSION" ]; then
+# Make sure the specified version is installed, resolving partials like "26"
+# to the latest matching installed version.
+if resolved="$(NODENV_VERSION="$version" nodenv-version-name 2>/dev/null)"; then
+  if [ "$resolved" != "$NODENV_VERSION" ]; then
     case "$shell" in
     fish )
       echo 'set -gu NODENV_VERSION_OLD "$NODENV_VERSION"'
-      echo "set -gx NODENV_VERSION \"$version\""
+      echo "set -gx NODENV_VERSION \"$resolved\""
       ;;
     zsh )
       echo "typeset -g NODENV_VERSION_OLD=\"\${NODENV_VERSION-}\""
-      echo "export NODENV_VERSION=\"$version\""
+      echo "export NODENV_VERSION=\"$resolved\""
       ;;
     * )
       echo 'NODENV_VERSION_OLD="${NODENV_VERSION-}"'
-      echo "export NODENV_VERSION=\"$version\""
+      echo "export NODENV_VERSION=\"$resolved\""
       ;;
     esac
   fi
 else
+  echo "nodenv: no installed version matches \`$version'" >&2
   echo "false"
   exit 1
 fi

--- a/libexec/nodenv-version-file-write
+++ b/libexec/nodenv-version-file-write
@@ -12,8 +12,11 @@ if [ -z "$NODENV_VERSION" ] || [ -z "$NODENV_VERSION_FILE" ]; then
   exit 1
 fi
 
-# Make sure the specified version is installed.
-nodenv-prefix "$NODENV_VERSION" >/dev/null
+# Make sure the specified version is installed, resolving partials like "26".
+if ! NODENV_VERSION="$NODENV_VERSION" nodenv-version-name >/dev/null 2>&1; then
+  echo "nodenv: no installed version matches \`$NODENV_VERSION'" >&2
+  exit 1
+fi
 
 # Write the version out to disk.
 echo "$NODENV_VERSION" > "$NODENV_VERSION_FILE"

--- a/libexec/nodenv-version-name
+++ b/libexec/nodenv-version-name
@@ -24,6 +24,17 @@ version_exists() {
   [ -d "${NODENV_ROOT}/versions/${version}" ]
 }
 
+# Highest installed version matching a partial like "26" or "26.3", or empty.
+latest_matching_version() {
+  local query="$1"
+  nodenv-versions --bare --skip-aliases \
+    | while IFS= read -r candidate; do
+        case "$candidate" in "$query"|"$query".*) echo "$candidate" ;; esac
+      done \
+    | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n \
+    | tail -n1
+}
+
 if version_exists "$NODENV_VERSION"; then
   echo "$NODENV_VERSION"
 elif version_exists "${NODENV_VERSION/v/}"; then
@@ -32,6 +43,14 @@ elif version_exists "${NODENV_VERSION#node-}"; then
   echo "${NODENV_VERSION#node-}"
 elif version_exists "${NODENV_VERSION#node-v}"; then
   echo "${NODENV_VERSION#node-v}"
+elif [[ ${NODENV_VERSION#v} =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  matched="$(latest_matching_version "${NODENV_VERSION#v}")"
+  if [ -n "$matched" ]; then
+    echo "$matched"
+  else
+    echo "nodenv: no installed version matches \`$NODENV_VERSION' (set by $(nodenv-version-origin))" >&2
+    exit 1
+  fi
 else
   echo "nodenv: version \`$NODENV_VERSION' is not installed (set by $(nodenv-version-origin))" >&2
   exit 1

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -18,7 +18,7 @@ create_executable() {
   export NODENV_VERSION="2.0"
   run nodenv-exec node -v
   assert_failure
-  assert_output "nodenv: version \`2.0' is not installed (set by NODENV_VERSION environment variable)"
+  assert_output "nodenv: no installed version matches \`2.0' (set by NODENV_VERSION environment variable)"
 }
 
 @test "fails with invalid version set from file" {
@@ -27,7 +27,7 @@ create_executable() {
   echo 1.9 > .node-version
   run nodenv-exec npm
   assert_failure
-  assert_output "nodenv: version \`1.9' is not installed (set by $PWD/.node-version)"
+  assert_output "nodenv: no installed version matches \`1.9' (set by $PWD/.node-version)"
 }
 
 @test "completes with names of executables" {

--- a/test/global.bats
+++ b/test/global.bats
@@ -25,11 +25,20 @@ load test_helper
   assert_output "1.2.3"
 }
 
+@test "set partial NODENV_ROOT/version" {
+  mkdir -p "$NODENV_ROOT/versions/26.3.1/bin"
+  run nodenv-global "26"
+  assert_success
+  run nodenv-global
+  assert_success
+  assert_output "26"
+}
+
 @test "fail setting invalid NODENV_ROOT/version" {
   mkdir -p "$NODENV_ROOT"
   run nodenv-global "1.2.3"
   assert_failure
-  assert_output "nodenv: version \`1.2.3' not installed"
+  assert_output "nodenv: no installed version matches \`1.2.3'"
 }
 
 @test "unset (remove) NODENV_ROOT/version" {

--- a/test/local.bats
+++ b/test/local.bats
@@ -46,6 +46,14 @@ setup() {
   assert [ "$(cat .node-version)" = "1.2.3" ]
 }
 
+@test "sets local partial version" {
+  mkdir -p "${NODENV_ROOT}/versions/26.3.1/bin"
+  run nodenv-local 26
+  assert_success
+  refute_output
+  assert [ "$(cat .node-version)" = "26" ]
+}
+
 @test "changes local version" {
   echo "1.0-pre" > .node-version
   mkdir -p "${NODENV_ROOT}/versions/1.2.3"

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -70,7 +70,7 @@ OUT
   run nodenv-sh-shell 1.2.3
   assert_failure
   assert_output - <<SH
-nodenv: version \`1.2.3' not installed
+nodenv: no installed version matches \`1.2.3'
 false
 SH
 }
@@ -82,6 +82,17 @@ SH
   assert_output - <<OUT
 NODENV_VERSION_OLD="\${NODENV_VERSION-}"
 export NODENV_VERSION="1.2.3"
+OUT
+}
+
+@test "shell change partial version" {
+  mkdir -p "${NODENV_ROOT}/versions/26.0.0/bin"
+  mkdir -p "${NODENV_ROOT}/versions/26.3.1/bin"
+  NODENV_SHELL=bash run nodenv-sh-shell 26
+  assert_success
+  assert_output - <<OUT
+NODENV_VERSION_OLD="\${NODENV_VERSION-}"
+export NODENV_VERSION="26.3.1"
 OUT
 }
 

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -19,7 +19,7 @@ setup() {
   assert [ ! -e ".node-version" ]
   run nodenv-version-file-write ".node-version" "1.8.7"
   assert_failure
-  assert_output "nodenv: version \`1.8.7' not installed"
+  assert_output "nodenv: no installed version matches \`1.8.7'"
   assert [ ! -e ".node-version" ]
 }
 
@@ -30,4 +30,21 @@ setup() {
   assert_success
   refute_output
   assert [ "$(cat my-version)" = "1.8.7" ]
+}
+
+@test "writes a partial version that matches an install" {
+  mkdir -p "${NODENV_ROOT}/versions/26.3.1/bin"
+  assert [ ! -e "my-version" ]
+  run nodenv-version-file-write "${PWD}/my-version" "26"
+  assert_success
+  refute_output
+  assert [ "$(cat my-version)" = "26" ]
+}
+
+@test "setting partial version with no match fails" {
+  mkdir -p "${NODENV_ROOT}/versions/27.0.0/bin"
+  run nodenv-version-file-write ".node-version" "26"
+  assert_failure
+  assert_output "nodenv: no installed version matches \`26'"
+  assert [ ! -e ".node-version" ]
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 create_version() {
-  mkdir -p "${NODENV_ROOT}/versions/$1"
+  mkdir -p "${NODENV_ROOT}/versions/$1/bin"
 }
 
 setup() {
@@ -78,7 +78,7 @@ SH
 @test "missing version" {
   NODENV_VERSION=1.2 run nodenv-version-name
   assert_failure
-  assert_output "nodenv: version \`1.2' is not installed (set by NODENV_VERSION environment variable)"
+  assert_output "nodenv: no installed version matches \`1.2' (set by NODENV_VERSION environment variable)"
 }
 
 @test "version with prefix in name" {
@@ -111,4 +111,73 @@ SH
   run nodenv-version-name
   assert_success
   assert_output "iojs-3.1.0"
+}
+
+@test "partial major version resolves to highest matching install" {
+  create_version "26.0.0"
+  create_version "26.3.1"
+  create_version "26.10.0"
+  create_version "27.0.0"
+  cat > ".node-version" <<<"26"
+  run nodenv-version-name
+  assert_success
+  assert_output "26.10.0"
+}
+
+@test "partial major version compares numerically not lexically" {
+  create_version "26.9.0"
+  create_version "26.10.0"
+  cat > ".node-version" <<<"26"
+  run nodenv-version-name
+  assert_success
+  assert_output "26.10.0"
+}
+
+@test "partial major version does not match across dot boundary" {
+  create_version "260.0.0"
+  NODENV_VERSION=26 run nodenv-version-name
+  assert_failure
+  assert_output "nodenv: no installed version matches \`26' (set by NODENV_VERSION environment variable)"
+}
+
+@test "partial major.minor version resolves to highest matching patch" {
+  create_version "26.3.0"
+  create_version "26.3.5"
+  create_version "26.4.0"
+  cat > ".node-version" <<<"26.3"
+  run nodenv-version-name
+  assert_success
+  assert_output "26.3.5"
+}
+
+@test "partial version with 'v' prefix resolves to highest matching install" {
+  create_version "26.3.1"
+  cat > ".node-version" <<<"v26"
+  run nodenv-version-name
+  assert_success
+  assert_output "26.3.1"
+}
+
+@test "exact version directory wins over partial match" {
+  create_version "26"
+  create_version "26.3.1"
+  cat > ".node-version" <<<"26"
+  run nodenv-version-name
+  assert_success
+  assert_output "26"
+}
+
+@test "partial version applies to NODENV_VERSION" {
+  create_version "26.0.0"
+  create_version "26.10.0"
+  NODENV_VERSION=26 run nodenv-version-name
+  assert_success
+  assert_output "26.10.0"
+}
+
+@test "partial version with no matching install fails" {
+  create_version "27.0.0"
+  NODENV_VERSION=26 run nodenv-version-name
+  assert_failure
+  assert_output "nodenv: no installed version matches \`26' (set by NODENV_VERSION environment variable)"
 }


### PR DESCRIPTION
Closes #240.

## Motivation — why this matters for developers

Today nodenv requires the **exact** patch version in `.node-version` (e.g. `26.3.1`). In practice teams only care about a major (or major.minor) line, and pinning the full patch creates day-to-day friction:

- **Constant churn.** Every patch bump (`26.3.1` → `26.3.2`) means editing and committing `.node-version` across every repo, even though any `26.x` would do. Security/patch updates that should be invisible turn into mechanical PRs.
- **"works on my machine" mismatches.** A teammate has `26.3.4` installed, the file says `26.3.1`, and nodenv errors out — so they either install an exact duplicate or hand-edit the file locally. A floating `26` just uses whatever `26.x` they already have.
- **Onboarding & CI drift.** New machines and CI images rarely have the exact patch pre-installed; `26` lets them run on the latest available `26.x` instead of failing the version check.
- **Parity with other version managers.** `nvm`, `asdf`, `volta`, and friends already accept partial/major specs. This brings nodenv in line with what developers expect.

The result: pin the line you actually care about (`26` or `26.3`), let patch releases flow in automatically, and stop babysitting `.node-version` files.

## Summary
- `.node-version`, the global version file, `NODENV_VERSION`, and `nodenv shell` now accept **partial versions**: a string with one or two numeric components resolves to the highest installed version matching that prefix at a dot boundary.
  - `26` → latest installed `26.*` (e.g. `26.10.0`)
  - `26.3` → latest installed `26.3.*` (e.g. `26.3.5`)
- Selection is numeric, not lexical (`26.10.0` > `26.9.0`), and respects dot boundaries (`26` never matches `260.0.0`).
- Exact-match resolution still takes precedence; a `v`-prefix is tolerated (`v26`).
- A partial with no matching install fails with a dedicated message: `nodenv: no installed version matches \`26' (set by <origin>)`.

## Version-setting commands
- `nodenv local 26` / `nodenv global 26` write the **literal** `26` to the version file, so it *floats* to the latest matching install on every read.
- `nodenv shell 26` *resolves* and exports the concrete version (e.g. `26.3.1`), pinning the current shell session — the env var holds a real value.

## Implementation
- Core resolution lives in `libexec/nodenv-version-name` (the single selection resolver), so it applies to all sources and flows through `nodenv exec` to the `node`/`npm` shims. New private `latest_matching_version` helper reuses `nodenv-versions --bare --skip-aliases` plus a portable numeric field sort (mirrors the existing `sort_versions` approach; BSD/GNU-safe).
- `libexec/nodenv-version-file-write` (used by `local`/`global`) and `libexec/nodenv-sh-shell` validate through the partial-aware resolver instead of an exact directory check.
- Full versions (`26.3.1`), `iojs-*`, and alias names keep today's exact behavior.

### Out of scope
A partial passed *directly* as an arg/env to `nodenv which 26` / `nodenv prefix 26` is not resolved — those commands short-circuit before the resolver. The select / set / run paths are all covered.

## Test plan
- [x] `npm test` — 200/200, 0 failures (new partial cases in `version-name`, `version-file-write`, `local`, `global`, `shell`; updated `exec` message assertions)
- [x] `shellcheck` — no new findings vs. baseline
- [x] Manual smoke against a real install set: `26`→`26.10.0`, `26.3`→`26.3.5`, `v26`→`26.10.0`, `99`→partial-miss error; `nodenv local 24`→file `24`, resolves `24.10.0`; `nodenv shell 24`→`export NODENV_VERSION="24.10.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)