### PR TITLE
Re-enable superlinter jscpd validation

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,4 @@
+{
+  "threshold": 0,
+  "ignore": ["**/README.md"]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
           VALIDATE_BIOME_FORMAT: false # conflicts with prettier
           VALIDATE_BIOME_LINT: false # conflicts with prettier
           VALIDATE_GIT_COMMITLINT: false # commitlint is bad
-          VALIDATE_JSCPD: false # jscpd is false-positive prone and generally not useful
           VALIDATE_SPELL_CODESPELL: false # codespell is buggy
           # TODO remove deviations from reusable superlinter config
           VALIDATE_BASH: false


### PR DESCRIPTION
Hi! I maintain jscpd, and while researching Super Linter adoption I ran into this line:

```yaml
VALIDATE_JSCPD: false # jscpd is false-positive prone and generally not useful
```

That was a reasonable call at the time — and since your env block says *"FIXME resolve failures for linters below and re-enable"*, I'd like to try to resolve this one.

Super Linter ships the new Rust-engine **jscpd v5** these days (`^5.0.16` since v8). Here's what it reports on the current nodenv tree:

```
Format    Files  Clones  Duplicated lines
bash         39       0        0 (0.00%)
json          2       0        0 (0.00%)
markdown      1       2       10 (2.23%)
perl          1       0        0 (0.00%)
yaml          6       0        0 (0.00%)
─────────────────────────────────────────
Total:       50       2       10 (0.23%)
time: 12ms
```

The only two findings are in `README.md` — overlapping command-reference blocks that are repetitive by design. So this PR:

- removes the `VALIDATE_JSCPD: false` deviation (per the `TODO remove deviations` note)
- adds `.github/linters/.jscpd.json` keeping Super Linter's zero-duplication default but excluding `README.md`

With that config the tree scans clean (`Found 0 clones`), so nothing starts failing — it just starts guarding the bash sources, which are genuinely clone-free (tidy codebase!).

If you happen to remember what false positives you ran into — markdown prose, short shell idioms, test fixtures — I'd be grateful for the details: feedback from the nodenv lineage is exactly what I want to use to improve v5's defaults. And if you'd prefer to keep it disabled, that's completely understandable — please feel free to close this; I'd still appreciate hearing about the false positives.
